### PR TITLE
Prefetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "mem_dbg",
  "memchr",
  "num-traits",
+ "prefetch-index",
  "proptest",
  "psacak",
  "rand",
@@ -489,6 +490,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "prefetch-index"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c3f29d949b65b31cbb5b151e8cf676950899630427f16923075e504c6c1d08"
 
 [[package]]
 name = "proc-macro-error-attr2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rayon = "1.11"
 
 savefile = { version = "0.20.1", optional = true, features = ["derive"] }
 mem_dbg = { version = "0.3", optional = true }
+prefetch-index = "0.1.0"
 
 [dev-dependencies]
 proptest = "1.6.0"

--- a/src/text_with_rank_support/block.rs
+++ b/src/text_with_rank_support/block.rs
@@ -77,11 +77,13 @@ impl MaybeSavefile for Block512 {}
 impl Block for Block512 {
     const NUM_BITS: usize = 512;
 
+    #[inline(always)]
     fn zeroes() -> Self {
         Self { data: [0; 8] }
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     fn negate(&mut self) {
         for i in 0..8 {
             self.data[i] = !self.data[i];
@@ -89,24 +91,28 @@ impl Block for Block512 {
     }
 
     #[doc(hidden)]
+    #[inline(always)]
     fn set_to_self_and(&mut self, other: Self) {
         for i in 0..8 {
             self.data[i] &= other.data[i];
         }
     }
 
+    #[inline(always)]
     fn get_bit(&self, idx: usize) -> u8 {
         let store_idx = idx / 64;
         let idx_in_store = idx % 64;
         ((self.data[store_idx] >> idx_in_store) & 1) as u8
     }
 
+    #[inline(always)]
     fn set_bit_assuming_zero(&mut self, idx: usize, bit: u8) {
         let store_idx = idx / 64;
         let idx_in_store = idx % 64;
         self.data[store_idx] |= (bit as u64) << idx_in_store;
     }
 
+    #[inline(always)]
     fn count_ones_before(&self, idx: usize) -> usize {
         let mut sum = 0;
 
@@ -119,10 +125,12 @@ impl Block for Block512 {
         sum as usize
     }
 
+    #[inline(always)]
     fn integrate_block_offset_assuming_zero(&mut self, block_offset: u64) {
         self.data[0] = block_offset;
     }
 
+    #[inline(always)]
     fn extract_block_offset_and_then_zeroize_it(&mut self) -> usize {
         let mask = !(u64::MAX << NUM_BLOCK_OFFSET_BITS);
         let block_offset = self.data[0] & mask;
@@ -152,35 +160,43 @@ impl MaybeSavefile for Block64 {}
 impl Block for Block64 {
     const NUM_BITS: usize = 64;
 
+    #[inline(always)]
     fn zeroes() -> Self {
         Self { data: 0 }
     }
 
+    #[inline(always)]
     fn negate(&mut self) {
         self.data = !self.data;
     }
 
+    #[inline(always)]
     fn set_to_self_and(&mut self, other: Self) {
         self.data &= other.data;
     }
 
+    #[inline(always)]
     fn get_bit(&self, idx: usize) -> u8 {
         ((self.data >> idx) & 1) as u8
     }
 
+    #[inline(always)]
     fn set_bit_assuming_zero(&mut self, idx: usize, bit: u8) {
         self.data |= (bit as u64) << idx;
     }
 
+    #[inline(always)]
     fn count_ones_before(&self, idx: usize) -> usize {
         let masked_data = self.data & !(u64::MAX << idx);
         masked_data.count_ones() as usize
     }
 
+    #[inline(always)]
     fn integrate_block_offset_assuming_zero(&mut self, block_offset: u64) {
         self.data = block_offset;
     }
 
+    #[inline(always)]
     fn extract_block_offset_and_then_zeroize_it(&mut self) -> usize {
         let mask = !(u64::MAX << NUM_BLOCK_OFFSET_BITS);
         let block_offset = self.data & mask;

--- a/src/text_with_rank_support/condensed.rs
+++ b/src/text_with_rank_support/condensed.rs
@@ -359,7 +359,9 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for CondensedTextWithRank
         prefetch_index(&self.interleaved_block_offsets, block_offset_idx);
 
         let block_range = self.block_range(idx);
-        prefetch_index(&self.interleaved_blocks, block_range.start);
+        for i in (block_range).step_by(512 / B::NUM_BITS) {
+            prefetch_index(&self.interleaved_blocks, i);
+        }
     }
 
     #[inline(always)]

--- a/src/text_with_rank_support/condensed.rs
+++ b/src/text_with_rank_support/condensed.rs
@@ -6,12 +6,10 @@ use crate::{
     maybe_savefile::MaybeSavefile, sealed::Sealed,
 };
 
-use super::{
-    block::{Block, Block64},
-    prefetch_index,
-};
+use super::block::{Block, Block64};
 
 use num_traits::{NumCast, PrimInt};
+use prefetch_index::prefetch_index;
 use rayon::prelude::*;
 
 // Interleaved means that the respective values for different symbols of the alphabet

--- a/src/text_with_rank_support/condensed.rs
+++ b/src/text_with_rank_support/condensed.rs
@@ -365,6 +365,15 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for CondensedTextWithRank
     }
 
     #[inline(always)]
+    fn prefetch_all(&self, idx: usize) {
+        debug_assert!(
+            std::mem::size_of::<I>() * self.alphabet_size <= 512,
+            "Prefetch_all assumes that the superblock offsets for all symbols fit into one cache line."
+        );
+        self.prefetch(0, idx);
+    }
+
+    #[inline(always)]
     fn symbol_at(&self, idx: usize) -> u8 {
         assert!(idx < self.text_len);
 

--- a/src/text_with_rank_support/condensed.rs
+++ b/src/text_with_rank_support/condensed.rs
@@ -30,15 +30,18 @@ pub struct CondensedTextWithRankSupport<I, B = Block64> {
 }
 
 impl<I: IndexStorage, B: Block> CondensedTextWithRankSupport<I, B> {
+    #[inline(always)]
     fn superblock_offset_idx(&self, symbol: u8, idx: usize) -> usize {
         let superblock_size = u16::MAX as usize + 1;
         (idx / superblock_size) * self.alphabet_size + symbol as usize
     }
 
+    #[inline(always)]
     fn block_offset_idx(&self, symbol: u8, idx: usize) -> usize {
         (idx / B::NUM_BITS) * self.alphabet_size + symbol as usize
     }
 
+    #[inline(always)]
     fn block_range(&self, idx: usize) -> Range<usize> {
         let alphabet_num_bits = ilog2_ceil_for_nonzero(self.alphabet_size);
         let interleaved_blocks_start = (idx / B::NUM_BITS) * alphabet_num_bits;
@@ -56,6 +59,7 @@ impl<I: IndexStorage, B: Block> Sealed for CondensedTextWithRankSupport<I, B> {}
 impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
     for CondensedTextWithRankSupport<I, B>
 {
+    #[inline(always)]
     fn construct_from_maybe_slice_compressed_text<S: SliceCompression>(
         text: &[u8],
         uncompressed_text_len: usize,
@@ -123,10 +127,12 @@ impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
         }
     }
 
+    #[inline(always)]
     fn _alphabet_size(&self) -> usize {
         self.alphabet_size
     }
 
+    #[inline(always)]
     fn _text_len(&self) -> usize {
         self.text_len
     }
@@ -288,6 +294,7 @@ impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
 }
 
 impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for CondensedTextWithRankSupport<I, B> {
+    #[inline(always)]
     unsafe fn rank_unchecked(&self, mut symbol: u8, idx: usize) -> usize {
         // SAFETY: all of the index accesses are in the valid range if idx is at most text.len()
         // and since the alphabet has a size of at least 2
@@ -340,6 +347,7 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for CondensedTextWithRank
         superblock_offset + block_offset + block_count
     }
 
+    #[inline(always)]
     fn symbol_at(&self, idx: usize) -> u8 {
         assert!(idx < self.text_len);
 
@@ -414,6 +422,7 @@ fn fill_superblock<I: PrimInt, B: Block, S: SliceCompression>(
     }
 }
 
+#[inline(always)]
 fn ilog2_ceil_for_nonzero(value: usize) -> usize {
     usize::BITS as usize - value.leading_zeros() as usize - value.is_power_of_two() as usize
 }

--- a/src/text_with_rank_support/flat.rs
+++ b/src/text_with_rank_support/flat.rs
@@ -33,17 +33,20 @@ pub struct FlatTextWithRankSupport<I, B = Block64> {
 }
 
 impl<I: IndexStorage, B: Block> FlatTextWithRankSupport<I, B> {
+    #[inline(always)]
     fn superblock_offset_idx(&self, symbol: u8, idx: usize) -> usize {
         let symbol_usize = symbol as usize;
         (idx / self.superblock_size) * self.alphabet_size + symbol_usize
     }
 
+    #[inline(always)]
     fn block_idx(&self, symbol: u8, idx: usize) -> usize {
         let symbol_usize = symbol as usize;
         let used_bits_per_block = B::NUM_BITS - NUM_BLOCK_OFFSET_BITS;
         (idx / used_bits_per_block) * self.alphabet_size + symbol_usize
     }
 
+    #[inline(always)]
     fn idx_in_block(idx: usize) -> usize {
         let used_bits_per_block = B::NUM_BITS - NUM_BLOCK_OFFSET_BITS;
         idx % used_bits_per_block
@@ -59,6 +62,7 @@ impl<I: IndexStorage, B: Block> Sealed for FlatTextWithRankSupport<I, B> {}
 impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
     for FlatTextWithRankSupport<I, B>
 {
+    #[inline(always)]
     fn construct_from_maybe_slice_compressed_text<S: SliceCompression>(
         text: &[u8],
         uncompressed_text_len: usize,
@@ -121,10 +125,12 @@ impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
         }
     }
 
+    #[inline(always)]
     fn _alphabet_size(&self) -> usize {
         self.alphabet_size
     }
 
+    #[inline(always)]
     fn _text_len(&self) -> usize {
         self.text_len
     }
@@ -218,6 +224,7 @@ impl<I: IndexStorage, B: Block> super::PrivateTextWithRankSupport<I>
 }
 
 impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for FlatTextWithRankSupport<I, B> {
+    #[inline(always)]
     unsafe fn rank_unchecked(&self, symbol: u8, idx: usize) -> usize {
         // SAFETY: all of the index accesses are in the valid range if idx is at most text.len()
         // and since the alphabet has a size of at least 2
@@ -245,6 +252,7 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for FlatTextWithRankSuppo
         superblock_offset + block_offset + block_count
     }
 
+    #[inline(always)]
     fn symbol_at(&self, idx: usize) -> u8 {
         assert!(idx < self.text_len);
 

--- a/src/text_with_rank_support/flat.rs
+++ b/src/text_with_rank_support/flat.rs
@@ -5,8 +5,8 @@ use crate::maybe_mem_dbg::MaybeMemDbg;
 use crate::maybe_savefile::MaybeSavefile;
 use crate::sealed::Sealed;
 
-use super::TextWithRankSupport;
 use super::block::{Block, Block64, NUM_BLOCK_OFFSET_BITS};
+use super::{TextWithRankSupport, prefetch_index};
 
 use num_traits::{NumCast, PrimInt};
 use rayon::prelude::*;
@@ -250,6 +250,15 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for FlatTextWithRankSuppo
         let block_count = block.count_ones_before(idx_in_block + NUM_BLOCK_OFFSET_BITS);
 
         superblock_offset + block_offset + block_count
+    }
+
+    #[inline(always)]
+    fn prefetch(&self, symbol: u8, idx: usize) {
+        let superblock_offset_idx = self.superblock_offset_idx(symbol, idx);
+        prefetch_index(&self.interleaved_superblock_offsets, superblock_offset_idx);
+
+        let block_idx = self.block_idx(symbol, idx);
+        prefetch_index(&self.interleaved_blocks, block_idx);
     }
 
     #[inline(always)]

--- a/src/text_with_rank_support/flat.rs
+++ b/src/text_with_rank_support/flat.rs
@@ -5,8 +5,9 @@ use crate::maybe_mem_dbg::MaybeMemDbg;
 use crate::maybe_savefile::MaybeSavefile;
 use crate::sealed::Sealed;
 
+use super::TextWithRankSupport;
 use super::block::{Block, Block64, NUM_BLOCK_OFFSET_BITS};
-use super::{TextWithRankSupport, prefetch_index};
+use prefetch_index::prefetch_index;
 
 use num_traits::{NumCast, PrimInt};
 use rayon::prelude::*;

--- a/src/text_with_rank_support/flat.rs
+++ b/src/text_with_rank_support/flat.rs
@@ -262,6 +262,21 @@ impl<I: IndexStorage, B: Block> TextWithRankSupport<I> for FlatTextWithRankSuppo
     }
 
     #[inline(always)]
+    fn prefetch_all(&self, idx: usize) {
+        let superblock_offset_idx = self.superblock_offset_idx(0, idx);
+        debug_assert!(
+            std::mem::size_of::<I>() * self.alphabet_size <= 512,
+            "Prefetch_all assumes that the superblock offsets for all symbols fit into one cache line."
+        );
+        prefetch_index(&self.interleaved_superblock_offsets, superblock_offset_idx);
+
+        let block_idx = self.block_idx(0, idx);
+        for i in (0..self.alphabet_size).step_by(512 / B::NUM_BITS) {
+            prefetch_index(&self.interleaved_blocks, block_idx + i);
+        }
+    }
+
+    #[inline(always)]
     fn symbol_at(&self, idx: usize) -> u8 {
         assert!(idx < self.text_len);
 

--- a/src/text_with_rank_support/mod.rs
+++ b/src/text_with_rank_support/mod.rs
@@ -103,6 +103,7 @@ pub trait TextWithRankSupport<I: IndexStorage>:
     /// Returns the number of occurrences of `symbol` in `text[0..idx]`.
     ///
     /// The running time is in O(1).
+    #[inline(always)]
     fn rank(&self, symbol: u8, idx: usize) -> usize {
         let is_safe = (symbol as usize) < self.alphabet_size() && idx <= self.text_len();
         assert!(is_safe);
@@ -123,10 +124,12 @@ pub trait TextWithRankSupport<I: IndexStorage>:
     /// The running time is in O(1).
     fn symbol_at(&self, idx: usize) -> u8;
 
+    #[inline(always)]
     fn text_len(&self) -> usize {
         self._text_len()
     }
 
+    #[inline(always)]
     fn alphabet_size(&self) -> usize {
         self._alphabet_size()
     }

--- a/src/text_with_rank_support/mod.rs
+++ b/src/text_with_rank_support/mod.rs
@@ -145,29 +145,6 @@ pub trait TextWithRankSupport<I: IndexStorage>:
     }
 }
 
-/// Prefetch the cache line containing (the first byte of) `data[index]` into
-/// all levels of the cache.
-#[inline(always)]
-pub fn prefetch_index<T>(data: impl AsRef<[T]>, index: usize) {
-    let ptr = data.as_ref().as_ptr().wrapping_add(index) as *const i8;
-    #[cfg(target_arch = "x86_64")]
-    unsafe {
-        std::arch::x86_64::_mm_prefetch(ptr, std::arch::x86_64::_MM_HINT_T0);
-    }
-    #[cfg(target_arch = "x86")]
-    unsafe {
-        std::arch::x86::_mm_prefetch(ptr, std::arch::x86::_MM_HINT_T0);
-    }
-    #[cfg(target_arch = "aarch64")]
-    unsafe {
-        std::arch::aarch64::_prefetch(ptr, std::arch::aarch64::_PREFETCH_LOCALITY3);
-    }
-    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86", target_arch = "aarch64")))]
-    {
-        // Do nothing.
-    }
-}
-
 // test functions from PrivateTextWithRankSupport here
 #[cfg(test)]
 mod tests {

--- a/src/text_with_rank_support/mod.rs
+++ b/src/text_with_rank_support/mod.rs
@@ -126,6 +126,9 @@ pub trait TextWithRankSupport<I: IndexStorage>:
         let _ = idx;
     }
 
+    /// Prefetch the data needed to answer `rank_unchecked(idx)` quickly.
+    fn prefetch_all(&self, idx: usize);
+
     /// Recoveres the symbol of the text at given index `idx`.
     ///
     /// The running time is in O(1).


### PR DESCRIPTION
This adds the ability to prefetch the cacheline required to answer a `rank` query.

~I'm not quite sure I did it correctly though...~ should be fixed now
In my evals (https://curiouscoding.nl/posts/quadrank/#evals), the data points (the black plusses) get better when going from `for` to `stream` with prefetch.

My wrapping code is here: https://github.com/RagnarGrootKoerkamp/quadrank/blob/master/src/genedex.rs